### PR TITLE
Add picture claim and update to Keycloak 26

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Dieses kleine Projekt verbindet diese beide Funktionen, sodass man sich per Open
 Account in allen Systemen einloggen kann, die OpenID Connect unterstützen.
 Darunter zählen Systeme wie WordPress, Synology oder Nextcloud.
 
-Getestet mit Keycloak 24.0.4.
+Getestet mit Keycloak 26.0.0.
 
 ## Installation
 
@@ -83,7 +83,7 @@ Bei manchen Anwendungen sorgen die Doppelpunkte allerdings für Probleme:
 
 ## Entwicklung
 
-Das Projekt kann mit Java 17 und Maven gebaut werden.
+Das Projekt kann mit Java 21 und Maven gebaut werden.
 
 ```bash
 mvn clean install

--- a/pom.xml
+++ b/pom.xml
@@ -3,19 +3,19 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>de.canchanchara.keylcoak.storage</groupId>
   <artifactId>custom-churchtools</artifactId>
-  <version>0.2.0-SNAPSHOT</version>
+  <version>0.3.0-SNAPSHOT</version>
   <name>custom-churchtools</name>
   <url>http://maven.apache.org</url>
 
   <packaging>jar</packaging>
-  <description>User Storage Provider for Church Tools</description>
+  <description>User Storage Provider for ChurchTools</description>
 
   <properties>
-    <version.keycloak>24.0.4</version.keycloak>
+    <version.keycloak>26.0.0</version.keycloak>
     <version.jackson>2.14.2</version.jackson>
 
-    <maven.compiler.source>17</maven.compiler.source>
-    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.source>21</maven.compiler.source>
+    <maven.compiler.target>21</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
   </properties>
@@ -35,7 +35,7 @@
     <dependency>
       <!-- Required for storage base classes -->
       <groupId>org.keycloak</groupId>
-      <artifactId>keycloak-model-jpa</artifactId>
+      <artifactId>keycloak-model-storage</artifactId>
       <version>${version.keycloak}</version>
     </dependency>
     <dependency>

--- a/src/main/java/de/canchanchara/keycloak/storage/AbstractAttributeUserAdapter.java
+++ b/src/main/java/de/canchanchara/keycloak/storage/AbstractAttributeUserAdapter.java
@@ -16,6 +16,7 @@ import java.util.stream.Stream;
  * AbstractUserAdapterFederatedStorage which is intended for bidirectional sync implementing UserFederatedStorageProvider.
  */
 public abstract class AbstractAttributeUserAdapter extends AbstractUserAdapter {
+    public static final String PICTURE = "picture";
     public static final String CREATED_TIMESTAMP = "createdTimestamp";
 
     public AbstractAttributeUserAdapter(KeycloakSession session, RealmModel realm, ComponentModel storageProviderModel) {
@@ -31,7 +32,7 @@ public abstract class AbstractAttributeUserAdapter extends AbstractUserAdapter {
     public String getFirstAttribute(String name) {
         List<String> values = getAttributes().get(name);
         if (values != null && !values.isEmpty())
-            return values.get(0);
+            return values.getFirst();
         else
             return null;
     }

--- a/src/main/java/de/canchanchara/keycloak/storage/ChurchToolsApi.java
+++ b/src/main/java/de/canchanchara/keycloak/storage/ChurchToolsApi.java
@@ -13,9 +13,11 @@ import org.jboss.logging.Logger;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URLEncoder;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 public class ChurchToolsApi {
@@ -42,8 +44,10 @@ public class ChurchToolsApi {
 
         logger.info("Find getUserByEmail: " + identifier);
 
+        String query = URLEncoder.encode(identifier, StandardCharsets.UTF_8);
+
         SearchResultDto searchResultDto =
-                get("/api/search?query=" + identifier + "&domainTypes[]=person", SearchResultDto.class);
+                get("/api/search?query=" + query + "&domainTypes[]=person", SearchResultDto.class);
 
         // Search may return multiple people for the same username, but we need an exact match
         for (SearchResultDataDto searchResult : searchResultDto.getData()) {

--- a/src/main/java/de/canchanchara/keycloak/storage/ChurchToolsApi.java
+++ b/src/main/java/de/canchanchara/keycloak/storage/ChurchToolsApi.java
@@ -8,7 +8,6 @@ import de.canchanchara.keycloak.storage.churchtools.model.PersonListDto;
 import de.canchanchara.keycloak.storage.churchtools.model.SearchResultDataDto;
 import de.canchanchara.keycloak.storage.churchtools.model.SearchResultDto;
 import de.canchanchara.keycloak.storage.churchtools.model.SinglePersonListDto;
-import org.apache.commons.lang3.StringUtils;
 import org.jboss.logging.Logger;
 
 import java.io.IOException;
@@ -93,10 +92,18 @@ public class ChurchToolsApi {
 
         logger.info("findPersons searchTerm:" + userSearchTerm + " firstResult: " + firstResult + " maxResults: " + maxResults);
 
+        if (userSearchTerm == null || userSearchTerm.isBlank())
+            return List.of();
+
         StringBuilder personFilter = new StringBuilder();
 
-        if (StringUtils.isNotEmpty(userSearchTerm)) {
+        // ChurchTools does not support wildcard search
+        if (!userSearchTerm.equals("*")) {
+
             List<String> personIds = findPersonsBySearchTerm(userSearchTerm);
+            if (personIds.isEmpty())
+                return List.of();
+
             for (String personId : personIds) {
                 personFilter.append("&ids%5B%5D=");
                 personFilter.append(personId);
@@ -106,7 +113,7 @@ public class ChurchToolsApi {
         PersonListDto personListDto = get("/api/persons?is_archived=false&page=" + 1 + "&limit=" + 500 + personFilter, PersonListDto.class);
 
         return personListDto.getData().stream()
-                .filter(p -> StringUtils.isNotEmpty(p.getCmsUserId()))
+                .filter(p -> p.getCmsUserId() != null && !p.getCmsUserId().isEmpty())
                 .skip(firstResult == null ? 0 : firstResult)
                 .limit(maxResults == null ? 1000 : maxResults)
                 .toList();

--- a/src/main/java/de/canchanchara/keycloak/storage/ChurchToolsUserAdapter.java
+++ b/src/main/java/de/canchanchara/keycloak/storage/ChurchToolsUserAdapter.java
@@ -20,17 +20,32 @@ public class ChurchToolsUserAdapter extends AbstractAttributeUserAdapter {
     public ChurchToolsUserAdapter(KeycloakSession session, RealmModel realm, ComponentModel model, PersonDto person) {
         super(session, realm, model);
         storageId = new StorageId(model.getId(), person.getId());
-        attributes = Map.of(
-                UserModel.FIRST_NAME, List.of(person.getFirstName()),
-                UserModel.LAST_NAME, List.of(person.getLastName()),
-                UserModel.EMAIL, List.of(person.getEmail()),
-                UserModel.EMAIL_VERIFIED, List.of(Boolean.toString(true)),
-                UserModel.USERNAME, List.of(person.getCmsUserId()),
-                UserModel.ENABLED, List.of(Boolean.toString(true)),
-                CREATED_TIMESTAMP, List.of(Long.toString(
-                        Instant.parse(person.getMeta().getCreatedDate()).toEpochMilli()
-                ))
-        );
+        if (person.getImageUrl() == null) {
+            attributes = Map.of(
+                    UserModel.FIRST_NAME, List.of(person.getFirstName()),
+                    UserModel.LAST_NAME, List.of(person.getLastName()),
+                    UserModel.EMAIL, List.of(person.getEmail()),
+                    UserModel.EMAIL_VERIFIED, List.of(Boolean.toString(true)),
+                    UserModel.USERNAME, List.of(person.getCmsUserId()),
+                    UserModel.ENABLED, List.of(Boolean.toString(true)),
+                    CREATED_TIMESTAMP, List.of(Long.toString(
+                            Instant.parse(person.getMeta().getCreatedDate()).toEpochMilli()
+                    ))
+            );
+        } else {
+            attributes = Map.of(
+                    UserModel.FIRST_NAME, List.of(person.getFirstName()),
+                    UserModel.LAST_NAME, List.of(person.getLastName()),
+                    UserModel.EMAIL, List.of(person.getEmail()),
+                    UserModel.EMAIL_VERIFIED, List.of(Boolean.toString(true)),
+                    UserModel.USERNAME, List.of(person.getCmsUserId()),
+                    UserModel.ENABLED, List.of(Boolean.toString(true)),
+                    PICTURE, List.of(person.getImageUrl()),
+                    CREATED_TIMESTAMP, List.of(Long.toString(
+                            Instant.parse(person.getMeta().getCreatedDate()).toEpochMilli()
+                    ))
+            );
+        }
     }
 
     @Override

--- a/src/main/java/de/canchanchara/keycloak/storage/ChurchToolsUserStorageProvider.java
+++ b/src/main/java/de/canchanchara/keycloak/storage/ChurchToolsUserStorageProvider.java
@@ -97,17 +97,11 @@ public class ChurchToolsUserStorageProvider implements
     // UserQueryMethodsProvider
     @Override
     public Stream<UserModel> searchForUserStream(RealmModel realm, Map<String, String> params, Integer firstResult, Integer maxResults) {
-        logger.info("searchForUserStream with Search Params: firstResult" + firstResult + " maxResults " + maxResults);
-
         String searchString = params.get(UserModel.SEARCH);
 
-        // Suche nach "*" kann Church Tools nicht verstehen, daher Suche nach "" empty String
-        if (searchString == null || searchString.equals("*"))
-            searchString = "";
-        else
-            searchString = searchString.trim();
-
         List<PersonDto> persons = churchTools.findPersons(searchString, firstResult, maxResults);
+
+        logger.info("searchForUserStream with firstResult = %d, maxResults = %d found %d results".formatted(firstResult, maxResults, persons.size()));
 
         return persons.stream().map(p -> new ChurchToolsUserAdapter(session, realm, model, p));
     }

--- a/src/main/java/de/canchanchara/keycloak/storage/ChurchToolsUserStorageProviderFactory.java
+++ b/src/main/java/de/canchanchara/keycloak/storage/ChurchToolsUserStorageProviderFactory.java
@@ -1,6 +1,5 @@
 package de.canchanchara.keycloak.storage;
 
-import org.apache.commons.lang3.StringUtils;
 import org.jboss.logging.Logger;
 import org.keycloak.Config;
 import org.keycloak.component.ComponentModel;
@@ -24,7 +23,7 @@ public class ChurchToolsUserStorageProviderFactory implements UserStorageProvide
     public void init(Config.Scope configScope) {
         String host = configScope.get("host");
         String loginToken = configScope.get("login-token");
-        if (StringUtils.isEmpty(host) || StringUtils.isEmpty(loginToken))
+        if (host == null || host.isEmpty() || loginToken == null || loginToken.isEmpty())
             logger.warn("ChurchTools configuration is incomplete. User Federation with ChurchTools will not work.");
 
         churchTools = ChurchToolsApi.createWithLoginToken(host, loginToken);

--- a/src/main/java/de/canchanchara/keycloak/storage/churchtools/model/PersonDto.java
+++ b/src/main/java/de/canchanchara/keycloak/storage/churchtools/model/PersonDto.java
@@ -7,6 +7,7 @@ public class PersonDto {
     private String lastName;
     private String email;
     private String cmsUserId;
+    private String imageUrl;
     private PersonMetaDto meta;
 
     public PersonMetaDto getMeta() {
@@ -55,5 +56,13 @@ public class PersonDto {
 
     public void setCmsUserId(String cmsUserId) {
         this.cmsUserId = cmsUserId;
+    }
+
+    public String getImageUrl() {
+        return imageUrl;
+    }
+
+    public void setImageUrl(String imageUrl) {
+        this.imageUrl = imageUrl;
     }
 }


### PR DESCRIPTION
Ich habe den `picture` claim hinzugefügt (resolves #13) und außerdem die Anwendung auf Keycloak 26 aktualisiert. Java 17 wird dort nicht mehr unterstützt. Demnach habe ich die Zielversion auf Java 21 geändert.

Kleinere Anpassung gab es auch für die Suche. Dort habe ich den Code etwas umstrukturiert, sodass die Anfrage enkodiert wird und somit Leerzeichen enthalten kann und außerdem nicht einfach alle Ergebnisse angezeigt werden, falls keines zutreffend war so wie bisher.